### PR TITLE
debian: Bump epoch to 3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+webhelper (3:0-1) unstable; urgency=medium
+
+  * Bump epoch to 3, to disambiguate from gir1.2-webhelper2private-1.0
+    package formerly provided by eos-sdk, with epoch 2.
+
+ -- Philip Chimento <philip@endlessm.com>  Tue, 25 Apr 2017 18:02:47 -0700
+
 webhelper (0-1) unstable; urgency=low
 
   * Initial release


### PR DESCRIPTION
This is needed to disambiguate from the gir1.2-webhelper2private-1.0
package previously provided by eos-sdk with epoch 2.

https://phabricator.endlessm.com/T16652