### PR TITLE
js: Declare module export variables with "var"

### DIFF
--- a/webhelper/webhelper.js
+++ b/webhelper/webhelper.js
@@ -42,7 +42,7 @@ const EOS_URI_SCHEME = 'endless://';
  * You should set up any WebViews that you create, by connecting
  * <web_actions_handler()>, so that they can handle custom action URIs.
  */
-const Application = new Lang.Class({
+var Application = new Lang.Class({
     Name: 'WebApplication',
     Extends: Endless.Application,
 

--- a/webhelper/webhelper2.js
+++ b/webhelper/webhelper2.js
@@ -129,7 +129,7 @@ const WH2_DBUS_MAIN_PROGRAM_INTERFACE = '\
  * >});
  * >app.run(ARGV);
  */
-const WebHelper = new Lang.Class({
+var WebHelper = new Lang.Class({
     Name: 'WebHelper',
     GTypeName: 'Wh2WebHelper',
     Extends: GObject.Object,

--- a/webhelper/webhelper_private/config.js.in
+++ b/webhelper/webhelper_private/config.js.in
@@ -1,1 +1,1 @@
-const PKGLIBDIR = '@pkglibdir@';
+var PKGLIBDIR = '@pkglibdir@';


### PR DESCRIPTION
In ES6, variables declared with "const" and "let" go into the "lexical
scope" rather than the normal scope. Therefore, they are not available as
properties on modules. GJS preserves the old behaviour with a warning,
but we should fix our code anyway.

https://phabricator.endlessm.com/T18106